### PR TITLE
Update amazon-ecs-agent to expose 51679

### DIFF
--- a/a/amazon-ecs-agent.yml
+++ b/a/amazon-ecs-agent.yml
@@ -9,6 +9,7 @@ ecs-agent:
   - /var/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro
   ports:
   - "127.0.0.1:51678:51678"
+  - "127.0.0.1:51679:51679"
   environment:
   - ECS_LOGFILE=/log/ecs-agent.log
   - ECS_LOGLEVEL=info


### PR DESCRIPTION
Maps the ecs-agent credentials metadata port 51679 back to the ecs-agent containter